### PR TITLE
Update and rename CryoEngines.cfg to CryoTanks.cfg

### DIFF
--- a/Patches/CryoTanks.cfg
+++ b/Patches/CryoTanks.cfg
@@ -1,9 +1,9 @@
 //by TheRedTom
 
-@PART[CA_STME]:NEEDS[CryoEngines]{
+@PART[CA_STME]:NEEDS[CryoTanks]{
 @description = Further development of the KS-25 brought about this cheaper and lighter hydrogen powered engine.
 
-!MODULE[ModuleEnginesFX]
+!MODULE[ModuleEnginesFX]{}
 	MODULE
 	{
 		name = ModuleEnginesFX
@@ -39,9 +39,9 @@
 	}
 }
 
-@PART[SSME]:NEEDS[CryoEngines]{
+@PART[SSME]:NEEDS[CryoTanks]{
 
-!MODULE[ModuleEnginesFX]
+!MODULE[ModuleEnginesFX]{}
 	MODULE
 	{
 		name = ModuleEnginesFX


### PR DESCRIPTION
Changes the dependency to CryoTanks instead of CryoEngines as that is what provides the LH2.

Corrects missing curly brackets in the line that deletes the LFO engineFX module. Previously it caused LFO and LH2 engine modules to exist simultaneously causing plume breakage, ability to use both fuels at once etc.